### PR TITLE
Reduce the number of loops to prevent array index out of bounds

### DIFF
--- a/common_src/ellfunctions.c
+++ b/common_src/ellfunctions.c
@@ -123,7 +123,7 @@ void sncndn(double uu, double emmc, double *sn, double *cn, double *dn)
 		}
 		a = 1.0;
 		*dn = 1.0;
-		for ( i=1; i<=19; i++ ) {
+		for ( i=1; i<=13; i++ ) {
 			l = i;
 			em[i] = a;
 			en[i] = (emc = sqrt(emc));


### PR DESCRIPTION
In function sncndn, the number of loops exceeds the size of the array em, en. In some cases it returns incorrect results due to the program accessing unallocated memory.

How to fix?
This can be fixed by reducing the number of loops in function sncndn to prevent array index out of bounds.